### PR TITLE
Add Buttslap counter

### DIFF
--- a/MovementPlus/NewAbility/ButtslapAbility.cs
+++ b/MovementPlus/NewAbility/ButtslapAbility.cs
@@ -15,6 +15,7 @@ namespace MovementPlus.NewAbility
         private static readonly MyConfig ConfigSettings = MovementPlusPlugin.ConfigSettings;
 
         private float buttslapTimer;
+		private int buttslapAmount;
 
 
         public override void Init()
@@ -41,6 +42,7 @@ namespace MovementPlus.NewAbility
             else
             {
                 this.buttslapTimer = ConfigSettings.Buttslap.Timer.Value;
+				this.buttslapAmount = 0;
             }
             this.PerformButtslap();
             
@@ -98,7 +100,8 @@ namespace MovementPlus.NewAbility
             this.p.DoComboTimeOut(ConfigSettings.Buttslap.ComboAmount.Value);
 
             // Perform trick
-            this.p.DoTrick(0, "Buttslap");
+			this.buttslapAmount++;
+            this.p.DoTrick(0, $"Buttslap x{this.buttslapAmount}");
         }
     }
 }


### PR DESCRIPTION
Implements a counter to the buttslap ability, displayed in the trick name.

![image](https://github.com/yurilewd/BRC-MovementPlus/assets/42678262/b645c7df-5960-44a8-a603-409bf3be8120)

Also I hope this is not the wrong branch for PRs! I didn't use the dev one cause it seemed out of date.